### PR TITLE
Simplify `vec_count_ones`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FastPrimeSieve"
 uuid = "715f0e73-5d43-4f21-b094-9019e1b56aa3"
 authors = ["Harmen Stoppels <me@harmenstoppels.nl>"]
-version = "0.1.0"
+version = "0.1.1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/FastPrimeSieve.jl
+++ b/src/FastPrimeSieve.jl
@@ -4,23 +4,14 @@ const ps = (1, 7, 11, 13, 17, 19, 23, 29)
 
 """
 Population count of a vector of UInt8s for counting prime numbers.
-See https://github.com/JuliaLang/julia/issues/34059
 """
-function vec_count_ones(xs::Vector{UInt8}, n = length(xs))
+function vec_count_ones(xs::Vector{UInt8})
     count = 0
-    chunks = n ÷ sizeof(UInt)
-    GC.@preserve xs begin
-        ptr = Ptr{UInt}(pointer(xs))
-        for i in 1:chunks
-            count += count_ones(unsafe_load(ptr, i))
-        end
+    xs64 = reinterpret(UInt, xs)
+    @simd for x in xs64
+        count += count_ones(x)
     end
-
-    @inbounds for i in 8chunks+1:n
-        count += count_ones(xs[i])
-    end
-
-    count
+    return count
 end
 
 function to_idx(x)


### PR DESCRIPTION
On my computer the new implementation is fast as the current one:
```julia
julia> function vec_count_ones(xs::Vector{UInt8}, n = length(xs))
           count = 0
           chunks = n ÷ sizeof(UInt)
           GC.@preserve xs begin
               ptr = Ptr{UInt}(pointer(xs))
               for i in 1:chunks
                   count += count_ones(unsafe_load(ptr, i))
               end
           end

           @inbounds for i in 8chunks+1:n
               count += count_ones(xs[i])
           end

           count
       end
vec_count_ones (generic function with 2 methods)

julia> function vec_count_ones_new(xs::Vector{UInt8})
           count = 0
           xs64 = reinterpret(UInt, xs)
           @simd for x in xs64
               count += count_ones(x)
           end
           return count
       end
vec_count_ones_new (generic function with 1 method)

julia> using BenchmarkTools

julia> v = rand(UInt8, 1024 ^ 2);

julia> @btime vec_count_ones($v)
  31.875 μs (0 allocations: 0 bytes)
4193684

julia> @btime vec_count_ones_new($v)
  31.709 μs (0 allocations: 0 bytes)
4193684

julia> versioninfo()
Julia Version 1.8.2
Commit 36034abf260 (2022-09-29 15:21 UTC)
Platform Info:
  OS: Linux (x86_64-linux-gnu)
  CPU: 8 × Intel(R) Core(TM) i7-4870HQ CPU @ 2.50GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-13.0.1 (ORCJIT, haswell)
  Threads: 1 on 8 virtual cores
```
and it vectorises as nicely:
```llvm
julia> @code_llvm debuginfo=:none vec_count_ones_new(v)
define i64 @julia_vec_count_ones_new_636({}* nonnull align 16 dereferenceable(40) %0) #0 {
top:
  %1 = alloca [3 x {}*], align 8
  %gcframe38 = alloca [3 x {}*], align 16
  %gcframe38.sub = getelementptr inbounds [3 x {}*], [3 x {}*]* %gcframe38, i64 0, i64 0
  %.sub = getelementptr inbounds [3 x {}*], [3 x {}*]* %1, i64 0, i64 0
  %2 = bitcast [3 x {}*]* %gcframe38 to i8*
  call void @llvm.memset.p0i8.i32(i8* noundef nonnull align 16 dereferenceable(24) %2, i8 0, i32 24, i1 false)
  %thread_ptr = call i8* asm "movq %fs:0, $0", "=r"() #8
  %ppgcstack_i8 = getelementptr i8, i8* %thread_ptr, i64 -8
  %ppgcstack = bitcast i8* %ppgcstack_i8 to {}****
  %pgcstack = load {}***, {}**** %ppgcstack, align 8
  %3 = bitcast [3 x {}*]* %gcframe38 to i64*
  store i64 4, i64* %3, align 16
  %4 = getelementptr inbounds [3 x {}*], [3 x {}*]* %gcframe38, i64 0, i64 1
  %5 = bitcast {}** %4 to {}***
  %6 = load {}**, {}*** %pgcstack, align 8
  store {}** %6, {}*** %5, align 8
  %7 = bitcast {}*** %pgcstack to {}***
  store {}** %gcframe38.sub, {}*** %7, align 8
  %8 = bitcast {}* %0 to { i8*, i64, i16, i16, i32 }*
  %9 = getelementptr inbounds { i8*, i64, i16, i16, i32 }, { i8*, i64, i16, i16, i32 }* %8, i64 0, i32 1
  %10 = load i64, i64* %9, align 8
  %11 = and i64 %10, 7
  %.not = icmp eq i64 %11, 0
  br i1 %.not, label %pass2, label %L13

L13:                                              ; preds = %top
  %12 = call nonnull {}* @ijl_box_int64(i64 signext %10)
  %13 = getelementptr inbounds [3 x {}*], [3 x {}*]* %gcframe38, i64 0, i64 2
  store {}* %12, {}** %13, align 16
  store {}* inttoptr (i64 140475673582816 to {}*), {}** %.sub, align 8
  %14 = getelementptr inbounds [3 x {}*], [3 x {}*]* %1, i64 0, i64 1
  store {}* inttoptr (i64 140475675074656 to {}*), {}** %14, align 8
  %15 = getelementptr inbounds [3 x {}*], [3 x {}*]* %1, i64 0, i64 2
  store {}* %12, {}** %15, align 8
  %16 = call nonnull {}* @ijl_invoke({}* inttoptr (i64 140475691269248 to {}*), {}** nonnull %.sub, i32 3, {}* inttoptr (i64 140475691269552 to {}*))
  call void @llvm.trap()
  unreachable

L118:                                             ; preds = %pass10, %middle.block, %pass2
  %value_phi17 = phi i64 [ 0, %pass2 ], [ %41, %middle.block ], [ %44, %pass10 ]
  %17 = load {}*, {}** %4, align 8
  %18 = bitcast {}*** %pgcstack to {}**
  store {}* %17, {}** %18, align 8
  ret i64 %value_phi17

pass2:                                            ; preds = %top
  %19 = lshr i64 %10, 3
  %20 = icmp ult i64 %10, 8
  br i1 %20, label %L118, label %pass10.lr.ph

pass10.lr.ph:                                     ; preds = %pass2
  %21 = bitcast {}* %0 to i8**
  %22 = load i8*, i8** %21, align 8
  %min.iters.check = icmp ult i64 %10, 128
  br i1 %min.iters.check, label %pass10, label %vector.ph

vector.ph:                                        ; preds = %pass10.lr.ph
  %n.vec = and i64 %19, 1152921504606846960
  br label %vector.body

vector.body:                                      ; preds = %vector.body, %vector.ph
  %index = phi i64 [ 0, %vector.ph ], [ %index.next, %vector.body ]
  %vec.phi = phi <4 x i64> [ zeroinitializer, %vector.ph ], [ %36, %vector.body ]
  %vec.phi29 = phi <4 x i64> [ zeroinitializer, %vector.ph ], [ %37, %vector.body ]
  %vec.phi30 = phi <4 x i64> [ zeroinitializer, %vector.ph ], [ %38, %vector.body ]
  %vec.phi31 = phi <4 x i64> [ zeroinitializer, %vector.ph ], [ %39, %vector.body ]
  %23 = shl nuw nsw i64 %index, 3
  %24 = getelementptr i8, i8* %22, i64 %23
  %25 = bitcast i8* %24 to <4 x i64>*
  %wide.load = load <4 x i64>, <4 x i64>* %25, align 1
  %26 = getelementptr i8, i8* %24, i64 32
  %27 = bitcast i8* %26 to <4 x i64>*
  %wide.load32 = load <4 x i64>, <4 x i64>* %27, align 1
  %28 = getelementptr i8, i8* %24, i64 64
  %29 = bitcast i8* %28 to <4 x i64>*
  %wide.load33 = load <4 x i64>, <4 x i64>* %29, align 1
  %30 = getelementptr i8, i8* %24, i64 96
  %31 = bitcast i8* %30 to <4 x i64>*
  %wide.load34 = load <4 x i64>, <4 x i64>* %31, align 1
  %32 = call <4 x i64> @llvm.ctpop.v4i64(<4 x i64> %wide.load)
  %33 = call <4 x i64> @llvm.ctpop.v4i64(<4 x i64> %wide.load32)
  %34 = call <4 x i64> @llvm.ctpop.v4i64(<4 x i64> %wide.load33)
  %35 = call <4 x i64> @llvm.ctpop.v4i64(<4 x i64> %wide.load34)
  %36 = add <4 x i64> %32, %vec.phi
  %37 = add <4 x i64> %33, %vec.phi29
  %38 = add <4 x i64> %34, %vec.phi30
  %39 = add <4 x i64> %35, %vec.phi31
  %index.next = add nuw i64 %index, 16
  %40 = icmp eq i64 %index.next, %n.vec
  br i1 %40, label %middle.block, label %vector.body

middle.block:                                     ; preds = %vector.body
  %bin.rdx = add <4 x i64> %37, %36
  %bin.rdx35 = add <4 x i64> %38, %bin.rdx
  %bin.rdx36 = add <4 x i64> %39, %bin.rdx35
  %41 = call i64 @llvm.vector.reduce.add.v4i64(<4 x i64> %bin.rdx36)
  %cmp.n = icmp eq i64 %19, %n.vec
  br i1 %cmp.n, label %L118, label %pass10

pass10:                                           ; preds = %pass10, %middle.block, %pass10.lr.ph
  %value_phi327 = phi i64 [ %45, %pass10 ], [ %n.vec, %middle.block ], [ 0, %pass10.lr.ph ]
  %value_phi26 = phi i64 [ %44, %pass10 ], [ %41, %middle.block ], [ 0, %pass10.lr.ph ]
  %42 = shl nuw nsw i64 %value_phi327, 3
  %scevgep = getelementptr i8, i8* %22, i64 %42
  %.0.scevgep.sroa_cast = bitcast i8* %scevgep to i64*
  %.0.copyload = load i64, i64* %.0.scevgep.sroa_cast, align 1
  %43 = call i64 @llvm.ctpop.i64(i64 %.0.copyload)
  %44 = add i64 %43, %value_phi26
  %45 = add nuw nsw i64 %value_phi327, 1
  %exitcond.not = icmp eq i64 %45, %19
  br i1 %exitcond.not, label %L118, label %pass10
}
```