### PR TITLE
Fix new definition of `vec_count_ones`

### DIFF
--- a/src/FastPrimeSieve.jl
+++ b/src/FastPrimeSieve.jl
@@ -7,17 +7,17 @@ Population count of a vector of UInt8s for counting prime numbers.
 """
 function vec_count_ones(xs::Vector{UInt8}, n = length(xs))
     count = 0
-    # Multiple of 8 less than or equal to n, 8 being `sizeof(UInt64) ÷ sizeof(UInt8)`.
-    n8 = n & -8
+    # Multiple of `sizeof(UInt64)` less than or equal to n
+    bytes = n & -sizeof(UInt64)
     # Running `count_ones` on `UInt64` can be vectorised much better than on
     # `UInt8`.  Let's reinterpret as much as possible of the vector as `UInt64`,
     # on the rest runs `count_ones` without packing.
-    xs64 = reinterpret(UInt64, @inbounds(@view(xs[1:n8])))
+    xs64 = reinterpret(UInt64, @inbounds(@view(xs[1:bytes])))
     @simd for x in xs64
         count += count_ones(x)
     end
     # Remainder of the vector which doesn't fit into a `UInt64`.
-    @simd for idx in (n8 + 1):n
+    @simd for idx in (bytes + 1):n
         count += @inbounds count_ones(xs[idx])
     end
     return count


### PR DESCRIPTION
I botched #4 because I didn't actually run the tests :see_no_evil:  There were two problems:

* I had dropped the second argument to `vec_count_ones`, but that's used to limit on how many elements to count the ones
* sometimes the vector `xs` doesn't have enough elements for being entirely reinterpreted as `UIn64`

Solution:

* restore the second argument and use it
* add a new loop to count the ones on the remainder of the vector that doesn't fit into a `UInt64`.

Some benchmarks (`vec_count_ones` is the original definition in this package, `FastPrimeSieve.vec_count_ones` is the one in this PR):
```julia
julia> v = rand(UInt8, 1);

julia> @btime vec_count_ones($v)
  5.428 ns (0 allocations: 0 bytes)
3

julia> @btime FastPrimeSieve.vec_count_ones($v)
  4.898 ns (0 allocations: 0 bytes)
3

julia> v = rand(UInt8, 7);

julia> @btime vec_count_ones($v)
  7.341 ns (0 allocations: 0 bytes)
36

julia> @btime FastPrimeSieve.vec_count_ones($v)
  7.069 ns (0 allocations: 0 bytes)
36

julia> v = rand(UInt8, 1024);

julia> @btime vec_count_ones($v)
  33.126 ns (0 allocations: 0 bytes)
4116

julia> @btime FastPrimeSieve.vec_count_ones($v)
  32.954 ns (0 allocations: 0 bytes)
4116

julia> v = rand(UInt8, 1024 ^ 2 + 7);

julia> @btime vec_count_ones($v)
  32.136 μs (0 allocations: 0 bytes)
4195704

julia> @btime FastPrimeSieve.vec_count_ones($v)
  32.106 μs (0 allocations: 0 bytes)
4195704
```

So this PR should have fixed the correctness issue while also matching old performance.